### PR TITLE
Implemented skipping and no interaction

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -I../ -I. -g
+CFLAGS += -Wall -I../ -I. -g
 EXEC = minunit_example.out
 
 $(EXEC):

--- a/examples/expected.txt
+++ b/examples/expected.txt
@@ -45,8 +45,12 @@ pass = false
 fail = "mu_input == 'y' at minunit_example.c:52"
 reason = "Everything ok?"
 
+[test_suite.test_skip]
+skipped = true
+
 
 [report]
-tests = 10
+tests = 11
 assertions = 10
 failures = 6
+skipped = 1

--- a/examples/minunit_example.c
+++ b/examples/minunit_example.c
@@ -52,6 +52,10 @@ MU_TEST(test_confirm) {
     mu_confirm("Everything ok?");
 }
 
+MU_TEST(test_skip) {
+    mu_skip();
+}
+
 
 MU_TEST_SUITE(test_suite) {
     MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -69,6 +73,7 @@ MU_TEST_SUITE(test_suite) {
 
     MU_RUN_TEST(test_fail);
     MU_RUN_TEST(test_confirm);
+    MU_RUN_TEST(test_skip);
 }
 
 MU_INIT();


### PR DESCRIPTION
Skipping can be done by calling mu_skip()
By defining MU_NO_INTERACTION all confirms are skipped by default